### PR TITLE
Add missing import os in const.py

### DIFF
--- a/resources/const.py
+++ b/resources/const.py
@@ -17,6 +17,7 @@
 
 # --- Python Standard Library ---
 import collections
+import os
 
 # --- Transitional code from Python 2 to Python 3 ---
 # See https://github.com/benjaminp/six/blob/master/six.py


### PR DESCRIPTION
Fix this issue:

```
2022-11-12 22:51:33.670 T:6774    ERROR <general>: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
                                                    - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
                                                   Error Type: <class 'NameError'>
                                                   Error Contents: name 'os' is not defined
                                                   Traceback (most recent call last):
                                                     File "/home/pi/.kodi/addons/plugin.program.AEL.dev/addon.py", line 18, in <module>
                                                       import resources.main
                                                     File "/home/pi/.kodi/addons/plugin.program.AEL.dev/resources/main.py", line 20, in <module>
                                                       import resources.const as const
                                                     File "/home/pi/.kodi/addons/plugin.program.AEL.dev/resources/const.py", line 45, in <module>
                                                       is_android_bool = _aux_is_android()
                                                     File "/home/pi/.kodi/addons/plugin.program.AEL.dev/resources/const.py", line 41, in _aux_is_android
                                                       return 'ANDROID_ROOT' in os.environ or 'ANDROID_DATA' in os.environ or 'XBMC_ANDROID_APK' in os.environ
                                                   NameError: name 'os' is not defined
                                                   -->End of Python script error report<--
```